### PR TITLE
ci: adds a method to calculate the affected base reference

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,15 @@
 def distributedTasks = [:]
 
+// This object provides a easy place to configure the known branches for your repository
+// for instance if you use a develop based trunk then you would update trunk to be be
+// "remotes/origin/develop"
+@groovy.transform.Field
+def BRANCHES = [
+  trunk: "remotes/origin/master",
+  beta: "remotes/origin/beta",
+  next: "remotes/origin/next",
+]
+
 stage("Building Distributed Tasks") {
   jsTask {
     checkout scm
@@ -46,7 +56,7 @@ def distributed(String target, int bins) {
 }
 
 def splitJobs(String target, int bins) {
-  def String baseSha = env.CHANGE_ID ? 'origin/master' : 'origin/master~1'
+  def String baseSha = getBaseRef(env.BRANCH_NAME, env.CHANGE_TARGET, BRANCHES)
   def String raw
   raw = sh(script: "npx nx print-affected --base=${baseSha} --target=${target}", returnStdout: true)
   def data = readJSON(text: raw)
@@ -62,4 +72,28 @@ def splitJobs(String target, int bins) {
   def split = tasks.collate(c)
 
   return split
+}
+
+ /**
+  * determines the baseRef for comparision when running the affected
+  * commans. If your repo uses different logic to determine the affected
+  * base then you should update this method.
+  *
+  * @param branchName   The current branch name
+  * @param changeTarget The branch where the PR is targeted
+  * @param branches     An object with keys for each branch and the reference it should map to
+  *
+  * @return             A string representing the git ref of the affected base
+  */
+def getBaseRef(String branchName, String changeTarget, Map<String, String> branches ){
+
+    String baseBranch = changeTarget == null ? branchName : changeTarget
+    String affectedBaseRef =  branches.containsKey(baseBranch) ? branches[baseBranch] : branches["trunk"]
+
+    if(!changeTarget){
+      affectedBaseRef += "~1"
+    }
+
+   return affectedBaseRef
+
 }


### PR DESCRIPTION
Adds a method that calculates the affected base ref. This function can be replaced by each project that uses this as an example if they use different logic. For the most part, this will accommodate most repos just by updating the `BRANCHES` object.